### PR TITLE
chore(server): 초기 Prisma 마이그레이션 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,14 @@ etc/
 # Database diagrams
 *.erd.json
 
-# Prisma generated files 
+# Prisma generated files
 **/generated/prisma/
 *.sql
+# but keep Prisma migration SQL (must be committed)
+!server/prisma/migrations/**/*.sql
 
 # Docker volumes
 postgres-data/
+
+# OMC tooling / session state
+**/.omc/

--- a/server/prisma/migrations/0_init/migration.sql
+++ b/server/prisma/migrations/0_init/migration.sql
@@ -1,0 +1,191 @@
+-- CreateSchema
+CREATE SCHEMA IF NOT EXISTS "public";
+
+-- CreateEnum
+CREATE TYPE "Provider" AS ENUM ('LOCAL', 'NAVER');
+
+-- CreateEnum
+CREATE TYPE "ContractType" AS ENUM ('JEONSE', 'WOLSE', 'MAEMAE');
+
+-- CreateEnum
+CREATE TYPE "ContractStatus" AS ENUM ('ACTIVE', 'EXPIRED', 'RENEWED', 'TERMINATED');
+
+-- CreateEnum
+CREATE TYPE "AlertType" AS ENUM ('D7', 'D30', 'D90');
+
+-- CreateEnum
+CREATE TYPE "StakeholderRole" AS ENUM ('OWNER', 'TENANT');
+
+-- CreateEnum
+CREATE TYPE "SyncStatus" AS ENUM ('SUCCESS', 'FAILED', 'PENDING');
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" UUID NOT NULL,
+    "email" VARCHAR(100),
+    "password" TEXT,
+    "name" VARCHAR(50) NOT NULL,
+    "provider" "Provider" NOT NULL DEFAULT 'LOCAL',
+    "naver_id" VARCHAR(50),
+    "naver_access_token" TEXT,
+    "naver_refresh_token" TEXT,
+    "push_token" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "properties" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "complex_name" VARCHAR(100) NOT NULL,
+    "building_name" VARCHAR(20) NOT NULL,
+    "unit_no" VARCHAR(20) NOT NULL,
+    "type_info" VARCHAR(50),
+    "note" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "properties_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "contracts" (
+    "id" UUID NOT NULL,
+    "property_id" UUID NOT NULL,
+    "contract_type" "ContractType" NOT NULL,
+    "deposit_price" BIGINT NOT NULL,
+    "monthly_rent" BIGINT NOT NULL DEFAULT 0,
+    "contract_date" DATE,
+    "expiration_date" DATE,
+    "status" "ContractStatus" NOT NULL DEFAULT 'ACTIVE',
+    "memo" TEXT,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "contracts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "alerts" (
+    "id" UUID NOT NULL,
+    "contract_id" UUID NOT NULL,
+    "alert_type" "AlertType" NOT NULL,
+    "scheduled_at" DATE NOT NULL,
+    "is_sent" BOOLEAN NOT NULL DEFAULT false,
+    "sent_at" TIMESTAMP(3),
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "alerts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "stakeholders" (
+    "id" UUID NOT NULL,
+    "contract_id" UUID NOT NULL,
+    "role" "StakeholderRole" NOT NULL,
+    "name" VARCHAR(50),
+    "phone" VARCHAR(20) NOT NULL,
+
+    CONSTRAINT "stakeholders_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "naver_calendar_events" (
+    "id" UUID NOT NULL,
+    "contract_id" UUID NOT NULL,
+    "naver_event_id" VARCHAR(100) NOT NULL,
+    "sync_status" "SyncStatus" NOT NULL DEFAULT 'SUCCESS',
+    "synced_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "naver_calendar_events_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "csv_import_logs" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "file_name" TEXT NOT NULL,
+    "total_rows" INTEGER NOT NULL DEFAULT 0,
+    "success_count" INTEGER NOT NULL DEFAULT 0,
+    "failed_count" INTEGER NOT NULL DEFAULT 0,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "csv_import_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "refresh_tokens" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "token" VARCHAR(500) NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "is_revoked" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "authorization_codes" (
+    "id" UUID NOT NULL,
+    "user_id" UUID NOT NULL,
+    "code" VARCHAR(128) NOT NULL,
+    "code_challenge" VARCHAR(128) NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "is_used" BOOLEAN NOT NULL DEFAULT false,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "authorization_codes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_naver_id_key" ON "users"("naver_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "refresh_tokens_token_key" ON "refresh_tokens"("token");
+
+-- CreateIndex
+CREATE INDEX "refresh_tokens_token_idx" ON "refresh_tokens"("token");
+
+-- CreateIndex
+CREATE INDEX "refresh_tokens_user_id_idx" ON "refresh_tokens"("user_id");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "authorization_codes_code_key" ON "authorization_codes"("code");
+
+-- CreateIndex
+CREATE INDEX "authorization_codes_code_idx" ON "authorization_codes"("code");
+
+-- CreateIndex
+CREATE INDEX "authorization_codes_user_id_idx" ON "authorization_codes"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "properties" ADD CONSTRAINT "properties_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "contracts" ADD CONSTRAINT "contracts_property_id_fkey" FOREIGN KEY ("property_id") REFERENCES "properties"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "alerts" ADD CONSTRAINT "alerts_contract_id_fkey" FOREIGN KEY ("contract_id") REFERENCES "contracts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "stakeholders" ADD CONSTRAINT "stakeholders_contract_id_fkey" FOREIGN KEY ("contract_id") REFERENCES "contracts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "naver_calendar_events" ADD CONSTRAINT "naver_calendar_events_contract_id_fkey" FOREIGN KEY ("contract_id") REFERENCES "contracts"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "csv_import_logs" ADD CONSTRAINT "csv_import_logs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "authorization_codes" ADD CONSTRAINT "authorization_codes_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+


### PR DESCRIPTION
## 배경
DB 스키마를 코드로 관리하는 마이그레이션 파일이 하나도 없었습니다. `server/prisma/migrations/`에 `migration_lock.toml`만 있어, `docker-entrypoint.sh`가 실행하는 `prisma migrate deploy`가 적용할 마이그레이션이 없었습니다.

그 결과 **컨테이너/DB를 새로 만들면 테이블이 생성되지 않아**, 네이버 로그인이 마지막 단계(`users` 조회)에서 500(`P2021: table public.users does not exist`)으로 실패했습니다.

## 변경 사항
- 기존 스키마를 초기 마이그레이션 `0_init`으로 baseline (`prisma migrate diff --from-empty`로 생성, 191줄)
  - 전체 테이블(users/properties/contracts/stakeholders/alerts/refresh_tokens/authorization_codes/csv_import_logs/naver_calendar_events) + enum 포함
- `.gitignore`의 포괄적 `*.sql` 규칙에서 Prisma 마이그레이션 SQL만 예외 처리(`!server/prisma/migrations/**/*.sql`) — 마이그레이션은 커밋되어야 하므로

## 효과
- 신규 환경에서 `migrate deploy`가 자동으로 전체 스키마를 생성 → 컨테이너 재생성 시 테이블 부재 문제 재발 방지

## 테스트
- [x] `prisma migrate status` → `Database schema is up to date!`
- [x] baseline이 기존 DB(db push로 생성된 스키마)와 일치 확인 (`migrate resolve --applied 0_init`)
- [x] main 머지 후 깨끗한 DB에서 `docker compose up`으로 테이블 자동 생성 재확인